### PR TITLE
fix warning deprecated 'optimize'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -200,7 +200,6 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>${maven-compiler-plugin.version}</version>
           <configuration>
-            <optimize>true</optimize>
             <showDeprecation>true</showDeprecation>
             <showWarnings>true</showWarnings>
           </configuration>


### PR DESCRIPTION
Warning:
Parameter 'optimize' (user property 'maven.compiler.optimize') is deprecated: This property is a no-op in javac.