### PR TITLE
Print PMD errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -286,6 +286,9 @@
               <version>${pmd.version}</version>
             </dependency>
           </dependencies>
+          <configuration>
+            <printFailingErrors>true</printFailingErrors>
+          </configuration>
         </plugin>
         <plugin>
           <artifactId>maven-project-info-reports-plugin</artifactId>


### PR DESCRIPTION
Example:
```
[INFO] --- pmd:3.22.0:check (validate) @ mir-wizard ---
[INFO] PMD version: 7.0.0
[INFO] PMD Failure: org.mycore.mir.wizard.command.MIRWizardMCRCommand:25 Rule:UnnecessaryImport Priority:4 Unused import 'java.io.File'.
[INFO] PMD Failure: org.mycore.mir.wizard.command.MIRWizardMCRCommand:35 Rule:UnnecessaryImport Priority:4 Unused import 'org.mycore.common.content.MCRContent'.
[INFO] PMD Failure: org.mycore.mir.wizard.command.MIRWizardMCRCommand:36 Rule:UnnecessaryImport Priority:4 Unused import 'org.mycore.common.content.MCRJDOMContent'.
[INFO] PMD Failure: org.mycore.mir.wizard.command.MIRWizardMCRCommand:37 Rule:UnnecessaryImport Priority:4 Unused import 'org.mycore.common.xml.MCRURIResolver'.
[INFO] ------------------------------------------------------------------------
```